### PR TITLE
Add fixes for spelling errors in 2 verbs and 4 arguments.

### DIFF
--- a/data/neg-all.txt
+++ b/data/neg-all.txt
@@ -452,7 +452,7 @@ man lengthen rock
 ant lengthen dough
 woman lengthen knife
 oil lengthen cord
-student length house
+student lengthen house
 dog lick air
 tree lick frosting
 cat lick cloud
@@ -980,7 +980,7 @@ worm drag turtle
 lion drag skyscraper
 monkey drain ocean
 girl drain ocean
-spetula drain sand
+spatula drain sand
 clown drain air
 dentist drain rock
 lion draw phone
@@ -1030,7 +1030,7 @@ shirt erase house
 scissors erase lake
 rabbit erect building
 girl erect water
-spetula erect horse
+spatula erect horse
 rabbit erect skyscraper
 man erect wind
 pillow etch pebbles
@@ -1222,7 +1222,7 @@ man lengthen pebbles
 worm lengthen dough
 clown lengthen knife
 oil lengthen brick
-dentist length house
+dentist lengthen house
 dog lick smoke
 bush lick frosting
 bear lick cloud

--- a/data/pos-all.txt
+++ b/data/pos-all.txt
@@ -30,7 +30,7 @@ arms bend flowers
 spoon bend paper
 wolf bite tongue
 cat bite rabbit
-ant bit man
+ant bite man
 baker bite cake
 flea bite dog
 television break fridge
@@ -173,7 +173,7 @@ rock crush box
 man crush child
 child crush bug
 dog crush plant
-sisewalk curb wheels
+sidewalk curb wheels
 step curb car
 rock curb bike
 house curb train
@@ -800,7 +800,7 @@ knife bend spatula
 policeman bend lamp
 horse bite worm
 cat bite turtle
-bear bit girl
+bear bite girl
 clown bite chair
 wolf bite nail
 plane break skyscraper
@@ -833,7 +833,7 @@ bike capsize cup
 spatula capsize pan
 dentist capsize ship
 girl capsize turtle
-monkey carry grap
+monkey carry grape
 dog carry scissors
 cup carry water
 boat carry mud
@@ -964,7 +964,7 @@ rain dampen girl
 water dampen beans
 oil dampen trash
 lion destroy house
-cat destroy shir
+cat destroy shirt
 bear destroy cup
 stove destroy apple
 scissors destroy shirt


### PR DESCRIPTION
I noticed that there were some arguments (subject or object) which were clearly spelling errors: grap for grape, sisewalk for sidewalk, shir for shirt and spetula for spatula. And 2 errors in verbs: bit for bite, length for lengthen. I added fixes for all the instances of the spelling errors. I'm not sure if this was intentional and was mentioned in the paper, but I dont think I saw in the paper. Feel free to merge or add the changes if this seems correct! 